### PR TITLE
Add windows-latest and macos-latest to the build action 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,11 +12,5 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    # - name: Setup Bazel
-    #   uses: abhinavsingh/setup-bazel@v3
-    # - name: Bazel Build on Windows
-    #   if: matrix.os == 'windows'
-    #   run: ./bazel.exe build //...
     - name: Bazel Build
-      if: matrix.os != 'windows'
       run: bazel build //...

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,11 +12,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Setup Bazel
-      uses: abhinavsingh/setup-bazel@v3
-    - name: Bazel Build on Windows
-      if: matrix.os == 'windows'
-      run: ./bazel.exe build //...
+    # - name: Setup Bazel
+    #   uses: abhinavsingh/setup-bazel@v3
+    # - name: Bazel Build on Windows
+    #   if: matrix.os == 'windows'
+    #   run: ./bazel.exe build //...
     - name: Bazel Build
       if: matrix.os != 'windows'
       run: bazel build //...

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-20.04, macos-latest, windows-latest]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,11 +4,18 @@ on: [push]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
-    - uses: actions/checkout@v1
-    - name: Bazel Action
-      uses: Penn-Electric-Racing/bazel-action/1.1.0@master
-      with:
-        args: build //...
+    - uses: actions/checkout@v2
+    - name: Setup Bazel
+      uses: abhinavsingh/setup-bazel@v3
+    - name: Bazel Build on Windows
+      if: matrix.os == 'windows'
+      run: ./bazel.exe build //...
+    - name: Bazel Build
+      if: matrix.os != 'windows'
+      run: bazel build //...


### PR DESCRIPTION
For now this just tests that the project builds on all 3, but we should be able to make it generate build archives too.

I removed the reference to Penn-Electric-Racing/bazel-action since the runners already have bazel installed, so we should probably delete that repo now.